### PR TITLE
Implemented streaming support for the LLM response

### DIFF
--- a/custom_components/vicuna_conversation/conversation.py
+++ b/custom_components/vicuna_conversation/conversation.py
@@ -3,11 +3,13 @@
 from collections.abc import Callable, AsyncGenerator
 import json
 import logging
-from typing import Literal, Any
+from typing import Literal, Any, cast
 
 import openai
+from openai._streaming import AsyncStream
 from openai._types import NOT_GIVEN
 from openai.types.chat import (
+    ChatCompletionChunk,
     ChatCompletionMessageParam,
     ChatCompletionAssistantMessageParam,
     ChatCompletionMessage,
@@ -48,6 +50,10 @@ _LOGGER = logging.getLogger(__name__)
 
 # Max number of back and forth with the LLM to generate a response
 MAX_TOOL_ITERATIONS = 10
+
+
+# TODO FIX THIS BEFORE MERGE!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+ENABLE_STREAMING = True
 
 
 async def async_setup_entry(
@@ -145,6 +151,116 @@ async def _transform_response(
     yield data
 
 
+def _convert_content_to_param(
+    content: conversation.Content,
+) -> ChatCompletionMessageParam:
+    """Convert any native chat message for this agent to the native format."""
+    if content.role == "tool_result":
+        assert type(content) is conversation.ToolResultContent
+        return ChatCompletionToolMessageParam(
+            role="tool",
+            tool_call_id=content.tool_call_id,
+            content=json.dumps(content.tool_result),
+        )
+    if content.role != "assistant" or not content.tool_calls:
+        role: Literal["system", "user", "assistant", "developer"] = content.role
+        if role == "system":
+            role = "developer"
+        return cast(
+            ChatCompletionMessageParam,
+            {"role": content.role, "content": content.content},
+        )
+
+    # Handle the Assistant content including tool calls.
+    assert type(content) is conversation.AssistantContent
+    return ChatCompletionAssistantMessageParam(
+        role="assistant",
+        content=content.content,
+        tool_calls=[
+            ChatCompletionMessageToolCallParam(
+                id=tool_call.id,
+                function=Function(
+                    arguments=json.dumps(tool_call.tool_args),
+                    name=tool_call.tool_name,
+                ),
+                type="function",
+            )
+            for tool_call in content.tool_calls
+        ],
+    )
+
+
+async def _transform_stream(
+    result: AsyncStream[ChatCompletionChunk],
+) -> AsyncGenerator[conversation.AssistantContentDeltaDict]:
+    """Transform an OpenAI delta stream into HA format."""
+    current_tool_call: dict | None = None
+
+    async for chunk in result:
+        LOGGER.debug("Received chunk: %s", chunk)
+        choice = chunk.choices[0]
+
+        if choice.finish_reason:
+            if current_tool_call:
+                tool_args = []
+                if current_tool_call["tool_args"]:
+                    tool_args = json.loads(current_tool_call["tool_args"])
+                yield {
+                    "tool_calls": [
+                        llm.ToolInput(
+                            id=current_tool_call["id"],
+                            tool_name=current_tool_call["tool_name"],
+                            tool_args=tool_args,
+                        )
+                    ]
+                }
+
+            break
+
+        delta = chunk.choices[0].delta
+
+        # We can yield delta messages not continuing or starting tool calls
+        if current_tool_call is None and not delta.tool_calls:
+            yield {  # type: ignore[misc]
+                key: value
+                for key in ("role", "content")
+                if (value := getattr(delta, key)) is not None
+            }
+            continue
+
+        # When doing tool calls, we should always have a tool call
+        # object or we have gotten stopped above with a finish_reason set.
+        if (
+            not delta.tool_calls
+            or not (delta_tool_call := delta.tool_calls[0])
+            or not delta_tool_call.function
+        ):
+            continue
+
+        if current_tool_call and delta_tool_call.index == current_tool_call["index"]:
+            current_tool_call["tool_args"] += delta_tool_call.function.arguments or ""
+            continue
+
+        # We got tool call with new index, so we need to yield the previous
+        if current_tool_call:
+            yield {
+                "tool_calls": [
+                    llm.ToolInput(
+                        id=current_tool_call["id"],
+                        tool_name=current_tool_call["tool_name"],
+                        tool_args=json.loads(current_tool_call["tool_args"]),
+                    )
+                ]
+            }
+
+        current_tool_call = {
+            "index": delta_tool_call.index,
+            "id": delta_tool_call.id,
+            "tool_name": delta_tool_call.function.name,
+            "tool_args": delta_tool_call.function.arguments or "",
+        }
+
+
 class OpenAIConversationEntity(
     conversation.ConversationEntity, conversation.AbstractConversationAgent
 ):
@@ -239,21 +355,36 @@ class OpenAIConversationEntity(
                     top_p=options.get(CONF_TOP_P, RECOMMENDED_TOP_P),
                     temperature=options.get(CONF_TEMPERATURE, RECOMMENDED_TEMPERATURE),
                     user=chat_log.conversation_id,
+                    stream=ENABLE_STREAMING,
                 )
             except openai.OpenAIError as err:
-                LOGGER.error("Error talking to OpenAI: %s", err)
-                raise HomeAssistantError("Error talking to OpenAI") from err
+                LOGGER.error("Error talking to API: %s", err)
+                raise HomeAssistantError("Error talking to API") from err
 
-            response = result.choices[0].message
+            if ENABLE_STREAMING:
+                messages.extend(
+                    [
+                        _convert_content_to_param(content)
+                        async for content in chat_log.async_add_delta_content_stream(
+                            user_input.agent_id, _transform_stream(result)
+                        )
+                    ]
+                )
 
-            async for content in chat_log.async_add_delta_content_stream(
-                user_input.agent_id, _transform_response(response)
-            ):
-                if m := _convert_content_to_chat_message(content):
-                    messages.append(m)
+                if not chat_log.unresponded_tool_results:
+                    break
 
-            if not chat_log.unresponded_tool_results:
-                break
+            else:
+                response = result.choices[0].message
+
+                async for content in chat_log.async_add_delta_content_stream(
+                    user_input.agent_id, _transform_response(response)
+                ):
+                    if m := _convert_content_to_chat_message(content):
+                        messages.append(m)
+
+                if not chat_log.unresponded_tool_results:
+                    break
 
         intent_response = intent.IntentResponse(language=user_input.language)
         assert type(chat_log.content[-1]) is conversation.AssistantContent


### PR DESCRIPTION
Streaming is currently hardcoded to true, but will be fixed in the next commit. We will be running a dummy LLM request at configuration time and ensure that the LLM is available and streaming is supported. We will fall back to non-streaming if the API does not support it.

The functions `_convert_content_to_param()` and `_transform_stream()` are copied from [the last commit before Responses API support was added to Home Assistant](https://github.com/home-assistant/core/tree/214d14b06b7dfef7ffdf5099b5705d39ae764353/homeassistant/components/openai_conversation) with some minor changes to avoid errors.