### PR TITLE
Backport core integration improvements from PR 175580

### DIFF
--- a/custom_components/vicuna_conversation/__init__.py
+++ b/custom_components/vicuna_conversation/__init__.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 import logging
 from types import MappingProxyType
 
-import openai
+
 
 from homeassistant.config_entries import ConfigEntry, ConfigSubentry, ConfigType
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
+    HomeAssistantError,
+)
 from homeassistant.const import Platform, CONF_API_KEY
 from homeassistant.helpers import (
     device_registry as dr,
@@ -47,11 +51,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     try:
         client = await async_create_client(hass, entry.data)
         await async_list_models(client)
-    except openai.AuthenticationError as err:
-        _LOGGER.error("Invalid API key: %s", err)
-        return False
-    except openai.OpenAIError as err:
-        raise ConfigEntryNotReady(err) from err
+    except HomeAssistantError as err:
+        if err.translation_key == "invalid_auth":
+            raise ConfigEntryAuthFailed(
+                translation_domain=err.translation_domain,
+                translation_key=err.translation_key,
+                translation_placeholders=err.translation_placeholders,
+            ) from err
+        raise ConfigEntryNotReady(
+            translation_domain=err.translation_domain,
+            translation_key=err.translation_key,
+            translation_placeholders=err.translation_placeholders,
+        ) from err
 
     entry.runtime_data = client
 

--- a/custom_components/vicuna_conversation/config_flow.py
+++ b/custom_components/vicuna_conversation/config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.config_entries import (
     ConfigFlow,
     ConfigFlowResult,
 )
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.const import CONF_API_KEY, CONF_LLM_HASS_API, CONF_NAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.selector import (
@@ -116,10 +117,9 @@ class OpenAIConfigFlow(ConfigFlow, domain=DOMAIN):
             try:
                 self.client = await async_create_client(self.hass, user_input)
                 self.models = await async_list_models(self.client)
-            except openai.APIConnectionError:
-                errors["base"] = "cannot_connect"
-            except openai.AuthenticationError:
-                errors["base"] = "invalid_api_key"
+            except HomeAssistantError as err:
+                LOGGER.error("Connection validation failed: %s", err)
+                errors["base"] = err.translation_key or "unknown"
             except Exception:  # pylint: disable=broad-except
                 LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
@@ -141,19 +141,26 @@ class OpenAIConfigFlow(ConfigFlow, domain=DOMAIN):
         errors = {}
         if user_input is not None:
             model = user_input[CONF_CHAT_MODEL]
-            success = await async_validate_completions(
-                self.client,
-                model=model,
-                stream=False,
-            )
-            if not success:
-                errors["base"] = "cannot_connect"
-            else:
-                stream_support = await async_validate_completions(
+            try:
+                await async_validate_completions(
                     self.client,
                     model=model,
-                    stream=True,
+                    stream=False,
                 )
+            except HomeAssistantError as err:
+                LOGGER.error("Model completion validation failed: %s", err)
+                errors["base"] = err.translation_key or "unknown"
+            else:
+                try:
+                    await async_validate_completions(
+                        self.client,
+                        model=model,
+                        stream=True,
+                    )
+                    stream_support = True
+                except HomeAssistantError:
+                    stream_support = False
+
                 base_options = {
                     **user_input,
                     CONF_STREAMING: stream_support,
@@ -272,18 +279,42 @@ class ConversationSubentryFlowHandler(ConfigSubentryFlow):
     ) -> SubentryFlowResult:
         """Manage initial options."""
         # abort if entry is not loaded
-        if self._get_entry().state != ConfigEntryState.LOADED:
+        if self._get_entry().state is not ConfigEntryState.LOADED:
             return self.async_abort(reason="entry_not_loaded")
 
         options = self.options
 
         if user_input is not None:
             model = user_input[CONF_CHAT_MODEL]
-            stream_support = await async_validate_completions(
-                self._openai_client,
-                model=model,
-                stream=True,
-            )
+            try:
+                await async_validate_completions(
+                    self._openai_client,
+                    model=model,
+                    stream=False,
+                )
+            except HomeAssistantError as err:
+                LOGGER.error("Model completion validation failed: %s", err)
+                models = await self._get_models()
+                schema = openai_config_option_schema(
+                    self.hass, self._subentry_type, self._is_new, options, models
+                )
+                return self.async_show_form(
+                    step_id="init",
+                    data_schema=self.add_suggested_values_to_schema(
+                        vol.Schema(schema), user_input
+                    ),
+                    errors={"base": err.translation_key or "unknown"},
+                )
+
+            try:
+                await async_validate_completions(
+                    self._openai_client,
+                    model=model,
+                    stream=True,
+                )
+                stream_support = True
+            except HomeAssistantError:
+                stream_support = False
             user_input[CONF_STREAMING] = stream_support
             if user_input[CONF_RECOMMENDED] == self.last_rendered_recommended:
                 if self._is_new:

--- a/custom_components/vicuna_conversation/entity.py
+++ b/custom_components/vicuna_conversation/entity.py
@@ -10,25 +10,30 @@ import mimetypes
 from pathlib import Path
 from typing import Any, Literal, cast
 
-import openai
+from openai import AsyncOpenAI
 from openai._streaming import AsyncStream
-from openai._types import NOT_GIVEN
+from openai._types import Omit
 from openai.types.chat import (
-    ChatCompletionChunk,
-    ChatCompletionMessageParam,
-    ChatCompletionMessageFunctionToolCall,
+    ChatCompletion,
     ChatCompletionAssistantMessageParam,
+    ChatCompletionChunk,
+    ChatCompletionContentPartParam,
+    ChatCompletionContentPartTextParam,
+    ChatCompletionFunctionToolParam,
     ChatCompletionMessage,
+    ChatCompletionMessageFunctionToolCall,
+    ChatCompletionMessageParam,
     ChatCompletionMessageToolCallParam,
     ChatCompletionSystemMessageParam,
     ChatCompletionToolMessageParam,
-    ChatCompletionToolParam,
     ChatCompletionUserMessageParam,
 )
 from openai.types.chat.chat_completion_message_function_tool_call_param import Function
-from openai.types.shared_params import FunctionDefinition
+from openai.types.shared_params import FunctionDefinition, ResponseFormatJSONSchema
 import voluptuous as vol
 from voluptuous_openapi import convert
+
+from .openai_client import api_error_handler
 
 from homeassistant.components import conversation
 from homeassistant.config_entries import ConfigEntry, ConfigSubentry
@@ -60,7 +65,7 @@ _LOGGER = logging.getLogger(__name__)
 def _format_tool(
     tool: llm.Tool,
     custom_serializer: Callable[[Any], Any] | None,
-) -> ChatCompletionToolParam:
+) -> ChatCompletionFunctionToolParam:
     """Format tool specification."""
     tool_spec = FunctionDefinition(
         name=tool.name,
@@ -68,15 +73,23 @@ def _format_tool(
     )
     if tool.description:
         tool_spec["description"] = tool.description
-    return ChatCompletionToolParam(type="function", function=tool_spec)
+    return ChatCompletionFunctionToolParam(type="function", function=tool_spec)
 
 
 def _format_structured_output(
-    structure: vol.Schema, llm_api: llm.APIInstance | None
-) -> dict[str, Any]:
+    name: str, structure: vol.Schema, llm_api: llm.APIInstance | None
+) -> ResponseFormatJSONSchema:
     """Format structured output specification."""
-    return convert(
+    schema = convert(
         structure, custom_serializer=llm_api.custom_serializer if llm_api else None
+    )
+    return ResponseFormatJSONSchema(
+        type="json_schema",
+        json_schema={
+            "name": name,
+            "strict": True,
+            "schema": cast(dict[str, object], schema),
+        },
     )
 
 
@@ -128,7 +141,11 @@ def _decode_tool_arguments(arguments: str) -> Any:
     try:
         return json.loads(arguments)
     except json.JSONDecodeError as err:
-        raise HomeAssistantError(f"Unexpected tool argument response: {err}") from err
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="json_parse_error",
+            translation_placeholders={"message": str(err)},
+        ) from err
 
 
 async def _transform_response(
@@ -197,9 +214,12 @@ async def _transform_stream(
 ) -> AsyncGenerator[conversation.AssistantContentDeltaDict]:
     """Transform an OpenAI delta stream into HA format."""
     current_tool_call: dict[str, Any] | None = None
+    yielded_role = False
 
     async for chunk in result:
         LOGGER.debug("Received chunk: %s", chunk)
+        if not chunk.choices:
+            continue
         choice = chunk.choices[0]
 
         if choice.finish_reason:
@@ -209,7 +229,9 @@ async def _transform_stream(
                         llm.ToolInput(
                             id=current_tool_call["id"],
                             tool_name=current_tool_call["tool_name"],
-                            tool_args=json.loads(current_tool_call["tool_args"])
+                            tool_args=_decode_tool_arguments(
+                                current_tool_call["tool_args"]
+                            )
                             if current_tool_call["tool_args"]
                             else {},
                         )
@@ -217,18 +239,18 @@ async def _transform_stream(
                 }
             break
 
-        delta = chunk.choices[0].delta
+        delta = choice.delta
 
         # We can yield delta messages not continuing or starting tool calls
         if current_tool_call is None and not delta.tool_calls:
-            yield cast(
-                conversation.AssistantContentDeltaDict,
-                {
-                    key: value
-                    for key in ("role", "content")
-                    if (value := getattr(delta, key)) is not None
-                },
-            )
+            yield_dict: conversation.AssistantContentDeltaDict = {}
+            if not yielded_role and delta.role == "assistant":
+                yield_dict["role"] = "assistant"
+                yielded_role = True
+            if delta.content is not None:
+                yield_dict["content"] = delta.content
+            if yield_dict:
+                yield yield_dict
             continue
 
         # When doing tool calls, we should always have a tool call
@@ -251,7 +273,9 @@ async def _transform_stream(
                     llm.ToolInput(
                         id=current_tool_call["id"],
                         tool_name=current_tool_call["tool_name"],
-                        tool_args=json.loads(current_tool_call["tool_args"]),
+                        tool_args=_decode_tool_arguments(
+                            current_tool_call["tool_args"]
+                        ),
                     )
                 ]
             }
@@ -292,7 +316,7 @@ class CustomOpenAIBaseLLMEntity(Entity):
         """Generate an answer for the chat log."""
         options = self.subentry.data
 
-        tools: list[ChatCompletionToolParam] | None = None
+        tools: list[ChatCompletionFunctionToolParam] | None = None
         if chat_log.llm_api:
             tools = [
                 _format_tool(tool, chat_log.llm_api.custom_serializer)
@@ -306,13 +330,11 @@ class CustomOpenAIBaseLLMEntity(Entity):
             if (m := _convert_content_to_chat_message(content))
         ]
 
-        response_format: dict[str, Any] | None = None
+        response_format: ResponseFormatJSONSchema | Omit = Omit()
         if structure and structure_name:
-            schema = _format_structured_output(structure, chat_log.llm_api)
-            response_format = {
-                "type": "json_schema",
-                "json_schema": schema,
-            }
+            response_format = _format_structured_output(
+                structure_name, structure, chat_log.llm_api
+            )
 
         # Handle attachments by adding them to the last user message
         last_content = chat_log.content[-1]
@@ -331,51 +353,55 @@ class CustomOpenAIBaseLLMEntity(Entity):
                     current_content = user_msg.get("content")
                     if isinstance(current_content, str):
                         # Convert string content to list with text and files
-                        user_msg["content"] = cast(
-                            Any,
-                            [
-                                {"type": "text", "text": current_content},
-                                *files,
-                            ],
-                        )
+                        user_msg["content"] = [
+                            ChatCompletionContentPartTextParam(
+                                type="text", text=current_content
+                            ),
+                            *files,
+                        ]
                     break
 
-        client = self.entry.runtime_data
+        client: AsyncOpenAI = self.entry.runtime_data
+        streaming = bool(
+            self.entry.data.get(CONF_STREAMING, options.get(CONF_STREAMING, False))
+        )
 
         for _iteration in range(MAX_TOOL_ITERATIONS):
-            try:
+            with api_error_handler():
                 result = await client.chat.completions.create(
                     model=model,
                     messages=messages,
-                    tools=tools or NOT_GIVEN,
+                    tools=tools or Omit(),
                     response_format=response_format,
-                    max_tokens=options.get(CONF_MAX_TOKENS, RECOMMENDED_MAX_TOKENS),
-                    top_p=options.get(CONF_TOP_P, RECOMMENDED_TOP_P),
-                    temperature=options.get(CONF_TEMPERATURE, RECOMMENDED_TEMPERATURE),
+                    max_tokens=cast(
+                        int, options.get(CONF_MAX_TOKENS, RECOMMENDED_MAX_TOKENS)
+                    ),
+                    top_p=cast(float, options.get(CONF_TOP_P, RECOMMENDED_TOP_P)),
+                    temperature=cast(
+                        float, options.get(CONF_TEMPERATURE, RECOMMENDED_TEMPERATURE)
+                    ),
                     user=chat_log.conversation_id,
-                    stream=options.get(CONF_STREAMING),
+                    stream=cast(Any, streaming),
                 )
-            except openai.OpenAIError as err:
-                LOGGER.error("Error talking to API: %s", err)
-                raise HomeAssistantError("Error talking to API") from err
 
             convert_message: Callable[[Any], Any]
-            convert_stream: Callable[
-                [Any], AsyncGenerator[conversation.AssistantContentDeltaDict]
-            ]
-            if options.get(CONF_STREAMING):
+            async_generator: AsyncGenerator[conversation.AssistantContentDeltaDict]
+            if streaming:
                 convert_message = _convert_content_to_param
-                convert_stream = _transform_stream
+                async_generator = _transform_stream(
+                    cast(AsyncStream[ChatCompletionChunk], result)
+                )
             else:
                 convert_message = _convert_content_to_chat_message
-                convert_stream = _transform_response
-                result = result.choices[0].message
+                async_generator = _transform_response(
+                    cast(ChatCompletion, result).choices[0].message
+                )
 
             messages.extend(
                 [
                     msg
                     async for content in chat_log.async_add_delta_content_stream(
-                        self.entity_id, convert_stream(result)
+                        self.entity_id, async_generator
                     )
                     if (msg := convert_message(content))
                 ]
@@ -387,7 +413,7 @@ class CustomOpenAIBaseLLMEntity(Entity):
 
 async def async_prepare_files_for_prompt(
     hass: HomeAssistant, files: list[Path]
-) -> list[dict[str, Any]]:
+) -> list[ChatCompletionContentPartParam]:
     """Prepare files for OpenAI-compatible API.
 
     Caller needs to ensure that the files are allowed.
@@ -397,19 +423,24 @@ async def async_prepare_files_for_prompt(
         """Guess the file type based on the file extension."""
         return mimetypes.guess_type(str(file_path))
 
-    def append_files_to_content() -> list[dict[str, Any]]:
-        content: list[dict[str, Any]] = []
+    def append_files_to_content() -> list[ChatCompletionContentPartParam]:
+        content: list[ChatCompletionContentPartParam] = []
 
         for file_path in files:
             if not file_path.exists():
-                raise HomeAssistantError(f"`{file_path}` does not exist")
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="file_not_found",
+                    translation_placeholders={"file_path": str(file_path)},
+                )
 
             mime_type, _ = guess_file_type(file_path)
 
             if not mime_type or not mime_type.startswith(("image/", "application/pdf")):
                 raise HomeAssistantError(
-                    "Only images and PDF are supported by the OpenAI API, "
-                    f"`{file_path}` is not an image file or PDF"
+                    translation_domain=DOMAIN,
+                    translation_key="unsupported_file_type",
+                    translation_placeholders={"file_path": str(file_path)},
                 )
 
             base64_file = base64.b64encode(file_path.read_bytes()).decode("utf-8")

--- a/custom_components/vicuna_conversation/openai_client.py
+++ b/custom_components/vicuna_conversation/openai_client.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator, Mapping
+from contextlib import contextmanager
 import logging
-from typing import Any, Mapping, cast
+from typing import Any, cast
 
 import openai
 from openai._streaming import AsyncStream
@@ -15,10 +17,12 @@ from openai.types.chat import (
 
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.httpx_client import get_async_client
 
 from .const import (
     CONF_BASE_URL,
+    DOMAIN,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -47,12 +51,12 @@ async def async_create_client(
 
 async def async_list_models(client: openai.AsyncOpenAI) -> list[str]:
     """Return a list of models supported by the client."""
-
     models = []
-    async for model in client.with_options(timeout=_TIMEOUT).models.list():
-        models.append(model.id)
-        if len(models) >= _MAX_MODELS:
-            break
+    with api_error_handler():
+        async for model in client.with_options(timeout=_TIMEOUT).models.list():
+            models.append(model.id)
+            if len(models) >= _MAX_MODELS:
+                break
     return models
 
 
@@ -77,9 +81,9 @@ async def async_validate_completions(
     client: openai.AsyncOpenAI,
     model: str,
     stream: bool = False,
-) -> bool:
+) -> None:
     """Validate that we can speak to the model over the completions API."""
-    try:
+    with api_error_handler():
         result = await client.chat.completions.create(
             model=model,
             messages=_TEST_MESSAGES,
@@ -87,19 +91,79 @@ async def async_validate_completions(
             max_tokens=_TEST_MAX_TOKENS,
             stream=stream,
         )
-    except openai.OpenAIError as err:
-        _LOGGER.info("Error validating model %s (stream=%s): %s", model, stream, err)
-        # Can't talk to the model either because it doesn't support the model, stream, etc
-        return False
 
-    if stream:
-        try:
+        if stream:
             stream_result = cast(AsyncStream[ChatCompletionChunk], result)
             async for event in stream_result:
+                if not event.choices:
+                    continue
                 if event.choices[0].finish_reason is not None:
                     continue
-        except openai.OpenAIError as err:
-            _LOGGER.error("Error streaming completion result: %s", err)
-            return False
 
-    return True
+
+def _extract_error_message(err: openai.APIStatusError) -> str:
+    """Extract a clean error message from an APIStatusError response or message."""
+    error_message = ""
+    if err.response is not None:
+        try:
+            json_data = err.response.json()
+            if isinstance(json_data, dict) and "error" in json_data:
+                error_message = json_data["error"].get("message") or ""
+        except ValueError:
+            pass
+    return error_message or err.message or str(err)
+
+
+@contextmanager
+def api_error_handler() -> Generator[None]:
+    """Context manager to handle API errors and translate them to HomeAssistantErrors."""
+    try:
+        yield
+    except openai.APITimeoutError as err:
+        _LOGGER.error("Timeout talking to API: %s", err)
+        error_message = err.message or str(err)
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="timeout",
+            translation_placeholders={"message": error_message},
+        ) from err
+    except openai.APIConnectionError as err:
+        _LOGGER.error("Connection error talking to API: %s", err)
+        error_message = err.message or str(err)
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="cannot_connect",
+            translation_placeholders={"message": error_message},
+        ) from err
+    except openai.AuthenticationError as err:
+        _LOGGER.error("Authentication error talking to API: %s", err)
+        error_message = _extract_error_message(err)
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="invalid_auth",
+            translation_placeholders={"message": error_message},
+        ) from err
+    except openai.APIStatusError as err:
+        _LOGGER.error("Status error talking to API: %s", err)
+        error_message = _extract_error_message(err)
+
+        if err.status_code == 402:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="quota_exceeded",
+                translation_placeholders={"message": error_message},
+            ) from err
+
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="api_error",
+            translation_placeholders={"message": error_message},
+        ) from err
+    except openai.OpenAIError as err:
+        _LOGGER.error("Generic error talking to API: %s", err)
+        error_message = getattr(err, "message", None) or str(err)
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="api_error",
+            translation_placeholders={"message": error_message},
+        ) from err

--- a/custom_components/vicuna_conversation/translations/en.json
+++ b/custom_components/vicuna_conversation/translations/en.json
@@ -1,11 +1,26 @@
 {
   "config": {
+    "abort": {
+      "already_configured": "Service is already configured"
+    },
     "error": {
+      "api_error": "Unexpected error, see error logs",
       "cannot_connect": "Failed to connect",
       "invalid_api_key": "Invalid API key",
+      "invalid_auth": "Invalid API key/authentication",
+      "quota_exceeded": "Your account or API key has insufficient credits.",
+      "timeout": "Connection timed out.",
       "unknown": "Unexpected error, see error logs"
     },
     "step": {
+      "model": {
+        "data": {
+          "chat_model": "Model"
+        },
+        "data_description": {
+          "chat_model": "Select the model to use."
+        }
+      },
       "user": {
         "data": {
           "api_key": "API key",
@@ -15,55 +30,72 @@
           "api_key": "API key for the LLM service.",
           "base_url": "Base URL for the LLM service."
         }
-      },
-      "model": {
-        "data": {
-          "chat_model": "Model"
-        },
-        "data_description": {
-          "chat_model": "Select the model to use."
-        }
       }
-    },
-    "abort": {
-      "already_configured": "Service is already configured"
     }
   },
   "config_subentries": {
     "conversation": {
-      "initiate_flow": {
-        "user": "Add conversation agent",
-        "reconfigure": "Reconfigure conversation agent"
+      "abort": {
+        "cannot_connect": "Failed to connect",
+        "entry_not_loaded": "Cannot add things while the configuration is disabled.",
+        "invalid_auth": "Invalid API key/authentication",
+        "reauth_successful": "Re-authentication was successful",
+        "reconfigure_successful": "Re-configuration was successful"
       },
       "entry_type": "Conversation agent",
+      "initiate_flow": {
+        "reconfigure": "Reconfigure conversation agent",
+        "user": "Add conversation agent"
+      },
       "step": {
         "init": {
           "data": {
+            "chat_model": "Model",
+            "llm_hass_api": "Control Home Assistant",
+            "max_tokens": "Maximum tokens to return in response",
             "name": "[%key:common::config_flow::data::name%]",
             "prompt": "Instructions",
-            "chat_model": "Model",
-            "max_tokens": "Maximum tokens to return in response",
+            "recommended": "Recommended model settings",
             "temperature": "Temperature",
-            "top_p": "Top P",
-            "llm_hass_api": "Control Home Assistant",
-            "recommended": "Recommended model settings"
+            "top_p": "Top P"
           },
           "data_description": {
-            "prompt": "Instruct how the LLM should respond. This can be a template.",
             "chat_model": "Select the model to use.",
-            "max_tokens": "Select the maximum number of tokens to return.",
-            "temperature": "Select the temperature for response variability.",
-            "top_p": "Select the top P value for response diversity.",
             "llm_hass_api": "Select the level of control over Home Assistant.",
-            "recommended": "Select whether to use recommended model settings."
+            "max_tokens": "Select the maximum number of tokens to return.",
+            "prompt": "Instruct how the LLM should respond. This can be a template.",
+            "recommended": "Select whether to use recommended model settings.",
+            "temperature": "Select the temperature for response variability.",
+            "top_p": "Select the top P value for response diversity."
           }
         }
-      },
-      "abort": {
-        "entry_not_loaded": "Cannot add things while the configuration is disabled.",
-        "reconfigure_successful": "Re-configuration was successful",
-        "reauth_successful": "Re-authentication was successful"
       }
+    }
+  },
+  "exceptions": {
+    "api_error": {
+      "message": "API error: {message}."
+    },
+    "cannot_connect": {
+      "message": "Cannot connect to the server: {message}."
+    },
+    "file_not_found": {
+      "message": "File does not exist: {file_path}."
+    },
+    "invalid_auth": {
+      "message": "Invalid authentication: {message}."
+    },
+    "json_parse_error": {
+      "message": "Unexpected tool argument response: {message}."
+    },
+    "quota_exceeded": {
+      "message": "Your account or API key has insufficient credits: {message}."
+    },
+    "timeout": {
+      "message": "Connection timed out: {message}."
+    },
+    "unsupported_file_type": {
+      "message": "Only images and PDF are supported by the OpenAI API, {file_path} is not an image file or PDF."
     }
   }
 }

--- a/tests/test_ai_task.py
+++ b/tests/test_ai_task.py
@@ -108,9 +108,13 @@ async def test_generate_structured_data(
     assert mock_completion.call_args.kwargs["response_format"] == {
         "type": "json_schema",
         "json_schema": {
-            "type": "object",
-            "properties": {"value": {"type": "string"}},
-            "required": [],
+            "name": "Test Task",
+            "strict": True,
+            "schema": {
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+                "required": [],
+            },
         },
     }
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -143,7 +143,7 @@ async def test_config_flow_fail_completion(
     await hass.async_block_till_done()
 
     assert result.get("type") is FlowResultType.FORM
-    assert result.get("errors") == {"base": "cannot_connect"}
+    assert result.get("errors") == {"base": "api_error"}
 
     assert len(mock_setup.mock_calls) == 0
 


### PR DESCRIPTION
This PR backports a series of improvements, bug fixes, and typing enhancements from the Home Assistant core integration (`llama_cpp` PR 175580) to the custom integration (`vicuna_conversation`).

### Summary of Changes:
- **API Error Translation (`openai_client.py`)**: Unified API connection, timeout, authentication, and quota errors to translated `HomeAssistantError` objects using the `api_error_handler` manager.
- **Config Flow & Lifecycle (`__init__.py` & `config_flow.py`)**: Migrated user flows to catch translated exceptions, propagating cleaner UI errors, and modernized `ConfigEntryState.LOADED` comparison styles.
- **Structured Schema & Tool Specs (`entity.py`)**: Integrated `ResponseFormatJSONSchema` and `ChatCompletionFunctionToolParam` to align perfectly with core typing.
- **Stream Processing (`entity.py`)**: Improved stream transformation logic to handle finish reasons, format role attributes cleanly (yielding only once), and decode tool call arguments dynamically with translation keys.
- **File Prep Exceptions (`entity.py`)**: Provided translated error domains/keys for missing or unsupported files in prompt attachments.
- **Translation Exceptions (`translations/en.json`)**: Added standard translations for API exception keys (`api_error`, `cannot_connect`, `file_not_found`, etc.).
- **Tests**: Updated tests to match the new formats, verified all 25 unit tests pass, and cleaned up unused imports.