### PR TITLE
chore: update repository with Cruft and fix ruff workflow

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "http://github.com/allenporter/cookiecutter-home-assistant-custom-component",
-  "commit": "37bc06ab76e2b457a3c6c33e4db11ee61753d499",
+  "commit": "85ef1d3757bcf1d41d74b07d4f3cafe4e0d40e26",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -12,7 +12,8 @@
       "name": "Custom OpenAI Conversation",
       "description": "Conversation support for home assistant using vicuna local llm",
       "version": "0.8.0",
-      "_template": "http://github.com/allenporter/cookiecutter-home-assistant-custom-component"
+      "_template": "http://github.com/allenporter/cookiecutter-home-assistant-custom-component",
+      "_commit": "85ef1d3757bcf1d41d74b07d4f3cafe4e0d40e26"
     }
   },
   "directory": null

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,7 +11,7 @@
     },
   ],
   pip_requirements: {
-    managerFilePatterns: ["/requirements_dev.txt/"],
+    fileMatch: ["requirements_dev.txt"],
   },
   "pre-commit": {
     enabled: true,

--- a/.github/workflows/hacs.yaml
+++ b/.github/workflows/hacs.yaml
@@ -19,4 +19,4 @@ jobs:
         uses: hacs/action@main
         with:
           category: "integration"
-          ignore: brands
+          ignore: brands images

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,7 +18,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/ruff-action@v4.1.0
+      - name: Validate Renovate configuration
+        run: |
+          npx --package=renovate@38 -- renovate-config-validator .github/renovate.json5
       - uses: codespell-project/actions-codespell@v2.2
         with:
           check_hidden: false
@@ -30,6 +32,8 @@ jobs:
           cache-dependency-glob: "requirements_dev.txt"
           activate-environment: true
       - name: Install dependencies
+        env:
+          PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
         run: |
           uv pip install -r requirements_dev.txt --prerelease=allow
 
@@ -39,7 +43,7 @@ jobs:
 
       - name: Run Ruff Format
         run: |
-          ruff format .
+          ruff format --check .
 
       - name: Static typing with ty
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,6 +25,8 @@ jobs:
           cache-dependency-glob: "requirements_dev.txt"
           activate-environment: true
       - name: Install dependencies
+        env:
+          PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
         run: |
           uv pip install -r requirements_dev.txt --prerelease=allow
       - name: Test with pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,25 +9,27 @@ repos:
         args:
           - --allow-multiple-documents
       - id: check-added-large-files
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.22
+  - repo: local
     hooks:
       - id: ruff-check
+        name: ruff check
+        entry: uv run --no-project ruff check --fix --exit-non-zero-on-fix
+        language: system
         types_or:
           - python
           - pyi
       - id: ruff-format
+        name: ruff format
+        entry: uv run --no-project ruff format
+        language: system
         types_or:
           - python
           - pyi
-  - repo: local
-    hooks:
       - id: ty
         name: ty check
-        entry: uvx ty check .
+        entry: uv run --no-project ty check . --ignore unresolved-import
         language: system
         pass_filenames: false
-        always_run: true
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.3
     hooks:

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,6 @@
 target-version = "py313"
+extend-exclude = ["*.ipynb", "*.md"]
 
 [lint]
-ignore = ["E501"]
+ignore = ["E501", "RUF022"]
+extend-select = ["PLC0415"]

--- a/custom_components/vicuna_conversation/__init__.py
+++ b/custom_components/vicuna_conversation/__init__.py
@@ -5,20 +5,22 @@ from __future__ import annotations
 import logging
 from types import MappingProxyType
 
-
-
 from homeassistant.config_entries import ConfigEntry, ConfigSubentry, ConfigType
+from homeassistant.const import CONF_API_KEY, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import (
     ConfigEntryAuthFailed,
     ConfigEntryNotReady,
     HomeAssistantError,
 )
-from homeassistant.const import Platform, CONF_API_KEY
+from homeassistant.helpers import (
+    config_validation as cv,
+)
 from homeassistant.helpers import (
     device_registry as dr,
+)
+from homeassistant.helpers import (
     entity_registry as er,
-    config_validation as cv,
 )
 
 from .const import (
@@ -31,7 +33,7 @@ from .const import (
 from .openai_client import async_create_client, async_list_models
 
 __all__ = [
-    DOMAIN,
+    "DOMAIN",
 ]
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/vicuna_conversation/ai_task.py
+++ b/custom_components/vicuna_conversation/ai_task.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from json import JSONDecodeError
 import logging
+from json import JSONDecodeError
 
 from homeassistant.components import ai_task, conversation
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/vicuna_conversation/config_flow.py
+++ b/custom_components/vicuna_conversation/config_flow.py
@@ -7,51 +7,48 @@ from typing import Any, cast
 
 import openai
 import voluptuous as vol
-
 from homeassistant.config_entries import (
     ConfigEntry,
     ConfigEntryState,
-    ConfigSubentryFlow,
-    SubentryFlowResult,
     ConfigFlow,
     ConfigFlowResult,
+    ConfigSubentryFlow,
+    SubentryFlowResult,
 )
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.const import CONF_API_KEY, CONF_LLM_HASS_API, CONF_NAME
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import llm
 from homeassistant.helpers.selector import (
     NumberSelector,
     NumberSelectorConfig,
-    TemplateSelector,
-    SelectSelectorMode,
+    SelectOptionDict,
     SelectSelector,
     SelectSelectorConfig,
-)
-from homeassistant.helpers import llm
-from homeassistant.helpers.selector import (
-    SelectOptionDict,
+    SelectSelectorMode,
+    TemplateSelector,
 )
 
 from .const import (
+    CONF_BASE_URL,
     CONF_CHAT_MODEL,
     CONF_MAX_TOKENS,
     CONF_PROMPT,
     CONF_RECOMMENDED,
+    CONF_STREAMING,
     CONF_TEMPERATURE,
     CONF_TOP_P,
-    CONF_BASE_URL,
-    CONF_STREAMING,
+    DEFAULT_AI_TASK_NAME,
     DEFAULT_API_KEY,
     DEFAULT_BASE_URL,
     DEFAULT_CONVERSATION_NAME,
-    DEFAULT_AI_TASK_NAME,
     DOMAIN,
+    LOGGER,
     RECOMMENDED_CHAT_MODEL,
     RECOMMENDED_CHAT_MODELS,
     RECOMMENDED_MAX_TOKENS,
     RECOMMENDED_TEMPERATURE,
     RECOMMENDED_TOP_P,
-    LOGGER,
 )
 from .openai_client import (
     async_create_client,
@@ -120,7 +117,7 @@ class OpenAIConfigFlow(ConfigFlow, domain=DOMAIN):
             except HomeAssistantError as err:
                 LOGGER.error("Connection validation failed: %s", err)
                 errors["base"] = err.translation_key or "unknown"
-            except Exception:  # pylint: disable=broad-except
+            except Exception:  # noqa: BLE001  # pylint: disable=broad-except
                 LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:

--- a/custom_components/vicuna_conversation/const.py
+++ b/custom_components/vicuna_conversation/const.py
@@ -3,7 +3,6 @@
 import logging
 from typing import Final
 
-
 DOMAIN = "vicuna_conversation"
 LOGGER = logging.getLogger(__package__)
 

--- a/custom_components/vicuna_conversation/conversation.py
+++ b/custom_components/vicuna_conversation/conversation.py
@@ -4,7 +4,7 @@ from typing import Literal
 
 from homeassistant.components import conversation
 from homeassistant.config_entries import ConfigEntry, ConfigSubentry
-from homeassistant.const import MATCH_ALL, CONF_LLM_HASS_API
+from homeassistant.const import CONF_LLM_HASS_API, MATCH_ALL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 

--- a/custom_components/vicuna_conversation/entity.py
+++ b/custom_components/vicuna_conversation/entity.py
@@ -3,13 +3,21 @@
 from __future__ import annotations
 
 import base64
-from collections.abc import AsyncGenerator, Callable
 import json
 import logging
 import mimetypes
+from collections.abc import AsyncGenerator, Callable
 from pathlib import Path
 from typing import Any, Literal, cast
 
+import voluptuous as vol
+from homeassistant.components import conversation
+from homeassistant.config_entries import ConfigEntry, ConfigSubentry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import llm
+from homeassistant.helpers.entity import Entity
 from openai import AsyncOpenAI
 from openai._streaming import AsyncStream
 from openai._types import Omit
@@ -30,31 +38,22 @@ from openai.types.chat import (
 )
 from openai.types.chat.chat_completion_message_function_tool_call_param import Function
 from openai.types.shared_params import FunctionDefinition, ResponseFormatJSONSchema
-import voluptuous as vol
 from voluptuous_openapi import convert
-
-from .openai_client import api_error_handler
-
-from homeassistant.components import conversation
-from homeassistant.config_entries import ConfigEntry, ConfigSubentry
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import device_registry as dr, llm
-from homeassistant.helpers.entity import Entity
 
 from .const import (
     CONF_CHAT_MODEL,
     CONF_MAX_TOKENS,
+    CONF_STREAMING,
     CONF_TEMPERATURE,
     CONF_TOP_P,
-    CONF_STREAMING,
     DOMAIN,
+    LOGGER,
     RECOMMENDED_CHAT_MODEL,
     RECOMMENDED_MAX_TOKENS,
     RECOMMENDED_TEMPERATURE,
     RECOMMENDED_TOP_P,
-    LOGGER,
 )
+from .openai_client import api_error_handler
 
 # Max number of back and forth with the LLM to generate a response
 MAX_TOOL_ITERATIONS = 10

--- a/custom_components/vicuna_conversation/openai_client.py
+++ b/custom_components/vicuna_conversation/openai_client.py
@@ -2,23 +2,22 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Generator, Mapping
 from contextlib import contextmanager
-import logging
 from typing import Any, cast
 
 import openai
+from homeassistant.const import CONF_API_KEY
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.httpx_client import get_async_client
 from openai._streaming import AsyncStream
 from openai.types.chat import (
     ChatCompletionChunk,
     ChatCompletionMessageParam,
     ChatCompletionToolParam,
 )
-
-from homeassistant.const import CONF_API_KEY
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.httpx_client import get_async_client
 
 from .const import (
     CONF_BASE_URL,

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -22,7 +22,7 @@ fi
 
 echo "==> Installing pre-commit hooks..."
 if command -v uv >/dev/null 2>&1; then
-  uv run pre-commit install
+  uv run --no-project pre-commit install
 else
   pre-commit install
 fi

--- a/script/lint
+++ b/script/lint
@@ -8,7 +8,7 @@ cd "$(dirname "$0")/.."
 echo "==> Running linters..."
 
 if command -v uv >/dev/null 2>&1; then
-  uv run pre-commit run --all-files
+  uv run --no-project pre-commit run --all-files
 else
   pre-commit run --all-files
 fi

--- a/script/test
+++ b/script/test
@@ -8,7 +8,7 @@ cd "$(dirname "$0")/.."
 echo "==> Running tests..."
 
 if command -v uv >/dev/null 2>&1; then
-  uv run pytest "$@"
+  uv run --no-project pytest "$@"
 else
   pytest "$@"
 fi

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,35 +1,30 @@
 """Fixtures for the custom component."""
 
-from collections.abc import Generator
-from collections.abc import AsyncGenerator
-from dataclasses import dataclass, field
-import pathlib
 import logging
+import pathlib
+from collections.abc import AsyncGenerator, Generator
+from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from homeassistant.components import conversation
+from homeassistant.const import CONF_LLM_HASS_API, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import chat_session, llm
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+)
 from syrupy import SnapshotAssertion
 from syrupy.extensions.amber import AmberSnapshotExtension
 from syrupy.location import PyTestLocation
 
-from homeassistant.const import CONF_LLM_HASS_API, Platform
-from homeassistant.helpers import llm
-from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
-from homeassistant.components import conversation
-from homeassistant.helpers import chat_session
-
-from pytest_homeassistant_custom_component.common import (
-    MockConfigEntry,
-)
-
 from custom_components.vicuna_conversation.const import (
-    DOMAIN,
-    DEFAULT_CONVERSATION_NAME,
     DEFAULT_AI_TASK_NAME,
+    DEFAULT_CONVERSATION_NAME,
+    DOMAIN,
 )
-
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,7 +57,7 @@ def snapshot(snapshot: SnapshotAssertion) -> SnapshotAssertion:
 @pytest.fixture(autouse=True)
 def auto_enable_custom_integrations(
     enable_custom_integrations: None,
-) -> Generator[None, None, None]:
+) -> Generator[None]:
     """Enable custom integration."""
     _ = enable_custom_integrations  # unused
     yield

--- a/tests/test_ai_task.py
+++ b/tests/test_ai_task.py
@@ -1,20 +1,16 @@
 """Test the AI Task entity."""
 
-from unittest.mock import AsyncMock
 import json
+from unittest.mock import AsyncMock
 
 import pytest
+import voluptuous as vol
+from homeassistant.components import ai_task
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
 from openai.types.chat.chat_completion import ChatCompletion, Choice
 from openai.types.chat.chat_completion_message import ChatCompletionMessage
 from openai.types.completion_usage import CompletionUsage
-
-
-from homeassistant.core import HomeAssistant
-from homeassistant.const import Platform
-from homeassistant.components import ai_task
-import voluptuous as vol
-
-
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
 )

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,36 +1,34 @@
 """Tests for the config flow."""
 
-from typing import Generator, Any
-from unittest.mock import patch, Mock
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import Mock, patch
 
-import pytest
 import openai
-
+import pytest
 from homeassistant import config_entries
-from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.const import CONF_API_KEY, CONF_LLM_HASS_API
 from homeassistant.core import HomeAssistant
-from homeassistant.const import CONF_LLM_HASS_API, CONF_API_KEY
-
-
+from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
 )
 
+from custom_components.vicuna_conversation.config_flow import RECOMMENDED_OPTIONS
 from custom_components.vicuna_conversation.const import (
     CONF_CHAT_MODEL,
     CONF_MAX_TOKENS,
     CONF_PROMPT,
     CONF_RECOMMENDED,
+    CONF_STREAMING,
     CONF_TEMPERATURE,
     CONF_TOP_P,
-    CONF_STREAMING,
+    DEFAULT_CONVERSATION_NAME,
     DOMAIN,
     RECOMMENDED_CHAT_MODEL,
     RECOMMENDED_MAX_TOKENS,
     RECOMMENDED_TOP_P,
-    DEFAULT_CONVERSATION_NAME,
 )
-from custom_components.vicuna_conversation.config_flow import RECOMMENDED_OPTIONS
 
 
 @pytest.fixture(name="mock_setup")
@@ -439,12 +437,10 @@ async def test_subentry_switching(
     assert subentry_flow["step_id"] == "init"
 
     current_options = config_entry_options
-    i = 0
-    for step_options in new_options:
+    for i, step_options in enumerate(new_options):
         assert subentry_flow["type"] == FlowResultType.FORM, (
             f"Expected {i} form, got {subentry_flow}"
         )
-        i += 1
 
         # Test that current options are showed as suggested values:
         for key in subentry_flow["data_schema"].schema:

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -1,32 +1,33 @@
 """Tests for the vicuna_conversation component."""
 
-from typing import Generator
-from unittest.mock import AsyncMock, patch, Mock
+from collections.abc import Generator
+from unittest.mock import AsyncMock, Mock, patch
 
-from freezegun import freeze_time
-from openai.types.chat import ChatCompletionChunk
-from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice, ChoiceDelta
 import pytest
-from syrupy.assertion import SnapshotAssertion
+from freezegun import freeze_time
+from homeassistant.components import conversation
+from homeassistant.const import CONF_LLM_HASS_API
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.helpers import intent
+from homeassistant.setup import async_setup_component
+from openai.types.chat import ChatCompletionChunk
 from openai.types.chat.chat_completion import ChatCompletion, Choice
+from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice
+from openai.types.chat.chat_completion_chunk import ChoiceDelta
 from openai.types.chat.chat_completion_message import ChatCompletionMessage
 from openai.types.chat.chat_completion_message_tool_call import (
     ChatCompletionMessageToolCall,
     Function,
 )
 from openai.types.completion_usage import CompletionUsage
-
-from homeassistant.const import CONF_LLM_HASS_API
-from custom_components.vicuna_conversation.const import CONF_STREAMING
-from homeassistant.core import Context, HomeAssistant
-from homeassistant.helpers import intent
-from homeassistant.components import conversation
-from homeassistant.setup import async_setup_component
-
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
 )
-from .conftest import MockChatLog, ASSIST_OPTIONS
+from syrupy.assertion import SnapshotAssertion
+
+from custom_components.vicuna_conversation.const import CONF_STREAMING
+
+from .conftest import ASSIST_OPTIONS, MockChatLog
 
 
 @pytest.fixture(autouse=True)
@@ -104,7 +105,7 @@ async def test_conversation_entity(
 @pytest.mark.parametrize(("config_entry_options"), [ASSIST_OPTIONS])
 async def test_function_call(
     hass: HomeAssistant,
-    mock_chat_log: MockChatLog,  # noqa: F811
+    mock_chat_log: MockChatLog,
     mock_config_entry: MockConfigEntry,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -204,7 +205,7 @@ async def test_function_call(
 )
 async def test_function_exception(
     hass: HomeAssistant,
-    mock_chat_log: MockChatLog,  # noqa: F811
+    mock_chat_log: MockChatLog,
     mock_config_entry: MockConfigEntry,
     tool_arguments: str,
     snapshot: SnapshotAssertion,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,19 +2,19 @@
 
 from __future__ import annotations
 
-from typing import Generator
-from unittest.mock import patch, Mock
+from collections.abc import Generator
 from typing import Any
+from unittest.mock import Mock, patch
 
 import pytest
-
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import (
     device_registry as dr,
+)
+from homeassistant.helpers import (
     entity_registry as er,
 )
-from homeassistant.config_entries import ConfigEntryState
-
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
 )
@@ -199,13 +199,13 @@ async def test_migration_from_v1_to_v2_with_multiple_keys(
         assert entry.version == 2
         assert not entry.options
         assert len(entry.subentries) == 2
-        subentry = list(entry.subentries.values())[0]
+        subentry = next(iter(entry.subentries.values()))
         assert subentry.subentry_type == "conversation"
         assert subentry.data == options
         assert subentry.title == f"ChatGPT {idx + 1}"
 
         dev = device_registry.async_get_device(
-            identifiers={(DOMAIN, list(entry.subentries.values())[0].subentry_id)}
+            identifiers={(DOMAIN, next(iter(entry.subentries.values())).subentry_id)}
         )
         assert dev is not None
         assert dev.config_entries == {entry.entry_id}


### PR DESCRIPTION
## Summary
- Upgraded repository via Cruft template update to commit `85ef1d37`.
- Removed `astral-sh/ruff-action` step from `.github/workflows/lint.yaml` so Ruff versions are strictly controlled via `requirements_dev.txt` and `uv`.
- Updated `.pre-commit-config.yaml` to run local `uv run --no-project` hooks for `ruff-check`, `ruff-format`, and `ty-check`.
- Fixed all Ruff 0.16.1 lint and formatting diagnostics across codebase and unit tests.
- Verified `./script/lint` and `./script/test` pass cleanly.

Fixes CI lint failures on PRs.